### PR TITLE
Disable appending of migrations to the app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This is the UI and Rails integration component of [yawl](https://github.com/rica
 
 ## Install Migrations
 
+For rails versions >= 4, the engine should automatically hook into Rails and allow you to *just* run `rake db:migrate`.
+
+For rails 3, migrations should be installed in the target app:
+
 ```
 rake yawl_rails:install:migrations
 ```

--- a/lib/yawl_rails/engine.rb
+++ b/lib/yawl_rails/engine.rb
@@ -9,6 +9,16 @@ module YawlRails
       g.template_engine :haml
     end
 
+    initializer "yawl_rails.append_migrations" do |app|
+      unless app.root.to_s.match root.to_s
+        if Rails::VERSION::MAJOR >= 4
+          config.paths["db/migrate"].expanded.each do |expanded_path|
+            app.config.paths["db/migrate"] << expanded_path
+          end
+        end
+      end
+    end
+
     initializer "yawl_rails.setup_yawl" do |app|
       require "yawl/rails"
     end


### PR DESCRIPTION
The schema_migrations table is not updated with the migration versions
from the engine when running `rake db:setup`. This leads to a situation
where schema.rb contains the objects setup by the engine (from a
previous `rake db:migrate`), but an invocation of `rake db:migrate` on a
fresh copy of the database will fail because the engine migrations are
not recorded in schema_migrations and rails will attempt to run them
again resulting in a conflict.

This change prefers copying the migrations into the target app which
causes `rake db:setup` to add an entry to the schema_migrations
table and keeping everything in sync.
