### PR TITLE
fix redirect for restart

### DIFF
--- a/app/controllers/yawl_rails/processes_controller.rb
+++ b/app/controllers/yawl_rails/processes_controller.rb
@@ -25,8 +25,8 @@ module YawlRails
       @process.start_first_unfinished_step
 
       respond_to do |format|
-        format.html { redirect_to yawl_process_path(@process.id), :status => 303 }
-        format.json { render :json => @process.to_hash, :location => yawl_process_url(@process.id) }
+        format.html { redirect_to yawl_process_path(@process.name), :status => 303 }
+        format.json { render :json => @process.to_hash, :location => yawl_process_url(@process.name) }
       end
     end
 


### PR DESCRIPTION
I think this is the right thing to do (I encountered an issue with redirecting to the process id instead of name when retrying a failed process in my devcloud), but I can't seem to properly setup the database to run the tests, so I'm not sure if this is good or not.
